### PR TITLE
feat(deps): migrate to actions/create-github-app-token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,8 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
           node-version: 20
       - run: make docs
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
     steps:
-      - uses: krystal/release-please-manifest-action@68c5fc11479050edc1241ca43ac093c6af497619 # v1.0.1
+      - uses: krystal/release-please-manifest-action@092261975f7de95f39420852ffa44410d8e726bc # v2.0.0
         id: release
         with:
           app-id: ${{ vars.RELEASE_PLEASE_GITHUB_APP_ID }}

--- a/README.md
+++ b/README.md
@@ -1,33 +1,30 @@
-<h1 align="center">
-  release-please-manifest-action
-</h1>
+<div align="center">
 
-<p align="center">
-  <strong>
-    Opinionated action for running release-please in manifest mode.
-  </strong>
-</p>
+# release-please-manifest-action
 
-<p align="center">
-  <a href="https://github.com/krystal/release-please-manifest-action/releases"><img src="https://img.shields.io/github/v/tag/krystal/release-please-manifest-action?label=release" alt="GitHub tag (latest SemVer)"></a>
-  <a href="https://github.com/krystal/release-please-manifest-action/issues"><img src="https://img.shields.io/github/issues-raw/krystal/release-please-manifest-action.svg?style=flat&logo=github&logoColor=white" alt="GitHub issues"></a>
-  <a href="https://github.com/krystal/release-please-manifest-action/pulls"><img src="https://img.shields.io/github/issues-pr-raw/krystal/release-please-manifest-action.svg?style=flat&logo=github&logoColor=white" alt="GitHub pull requests"></a>
-  <a href="https://github.com/krystal/release-please-manifest-action/blob/master/LICENSE"><img src="https://img.shields.io/github/license/krystal/release-please-manifest-action.svg?style=flat" alt="License Status"></a>
-</p>
+**Opinionated action for running release-please in manifest mode.**
 
-A composite action which wraps [release-please-action][] and
-[github-app-token][] actions, with opinionated defaults.
+[![Latest Release](https://img.shields.io/github/release/krystal/release-please-manifest-action.svg)](https://github.com/krystal/release-please-manifest-action/releases)
+[![GitHub Issues](https://img.shields.io/github/issues/krystal/release-please-manifest-action.svg?style=flat&logo=github&logoColor=white)](https://github.com/krystal/release-please-manifest-action/issues)
+[![GitHub Pull Requests](https://img.shields.io/github/issues-pr/krystal/release-please-manifest-action.svg?style=flat&logo=github&logoColor=white)](https://github.com/krystal/release-please-manifest-action/pulls)
+[![License](https://img.shields.io/github/license/krystal/release-please-manifest-action.svg)](https://github.com/krystal/release-please-manifest-action/blob/main/LICENSE)
 
-_Note: This is a fork of
-[`jimeh/release-please-manifest-action`](https://github.com/jimeh/release-please-manifest-action),
-customized by [@krystal](https://github.com/krystal) for their own needs.
-Upstream changes will be included as appropriate._
+An opinionated composite action that wraps [release-please-action][] and
+[create-github-app-token][].
+
+</div>
 
 [release-please-action]: https://github.com/googleapis/release-please-action
-[github-app-token]: https://github.com/tibdex/github-app-token
-[release-please]: https://github.com/googleapis/release-please
+[create-github-app-token]: https://github.com/actions/create-github-app-token
 [manifest mode]:
   https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md
+
+> [!NOTE]
+>
+> This is a fork of
+> [`jimeh/release-please-manifest-action`](https://github.com/jimeh/release-please-manifest-action),
+> customized by [@krystal](https://github.com/krystal) for their own needs.
+> Upstream changes will be included as appropriate.
 
 # Features
 
@@ -40,12 +37,6 @@ Upstream changes will be included as appropriate._
 _Note: This action is not well suited for multi package/root release-please
 configurations, as it does not support dynamic path-based outputs. A workaround
 is to parse the `raw` output JSON string, but this is not ideal._
-
-# Breaking changes from v1 to v2
-
-- `default-branch` input was renamed to `target-branch`.
-- `installation-id` input has been replaced by `installation-retrieval-mode`.
-- `release-please` output was renamed to `raw`.
 
 # Usage
 
@@ -63,8 +54,8 @@ that is automatically available to all actions.
 
 This will prevent checks / GitHub Actions running against any Release Pull
 Requests raised by release-please. This is a feature of GitHub as a means of
-trying to avoid GitHub Actions jobs triggering themselves, causing an endless
-loop.
+trying to avoid GitHub Actions jobs triggering themselves, and causing infinite
+loops.
 
 If you need checks to run against Release Pull Requests, you will need to have
 release-please authenticate with a Personal Access Token (PAT), or as a GitHub
@@ -170,9 +161,8 @@ or a user's personal access token:
 Below we assume you have already setup `RELEASE_BOT_APP_ID` and
 `RELEASE_BOT_PRIVATE_KEY` secrets in the repository or organization.
 
-To set the private key secret, it is easiest to base64 encode the contents of
-the `*.pem` file you get from the GitHub App's configuration page. The base64
-encoded string should not have any line-breaks.
+To set the private key secret, simply copy/paste the contents of the `*.pem`
+file you get from the GitHub App's configuration page.
 
 <!-- x-release-please-start-major -->
 
@@ -201,11 +191,11 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
     steps:
-      - uses: tibdex/github-app-token@v2
+      - uses: actions/create-github-app-token@v2
         id: github-app-token
         with:
-          app_id: ${{ secrets.RELEASE_BOT_APP_ID }}
-          private_key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
       - uses: googleapis/release-please-action@v4
         id: release-please
         with:
@@ -250,22 +240,15 @@ when cherry picking.
 
 ## Inputs
 
-| parameter                      | description                                                                                                                                                                                                                                                                                                                                                                                            | required | default                               |
-| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------- | ------------------------------------- |
-| token                          | GitHub token used to authenticate.                                                                                                                                                                                                                                                                                                                                                                     | `false`  | ${{ github.token }}                   |
-| app-id                         | ID of the GitHub App to use for authentication. If set, takes precedence over token input.                                                                                                                                                                                                                                                                                                             | `false`  |                                       |
-| private-key                    | Private key of the GitHub App (can be Base64 encoded). Required when app-id is provided.                                                                                                                                                                                                                                                                                                               | `false`  |                                       |
-| installation-retrieval-mode    | When using app authentication, the mode used to retrieve the installation for which the token will be requested. For more information, see: https://github.com/tibdex/github-app-token/blob/v2/action.yml                                                                                                                                                                                              | `false`  | repository                            |
-| installation-retrieval-payload | When using app authentication, the payload used to retrieve the installation. For more information, see: https://github.com/tibdex/github-app-token/blob/v2/action.yml                                                                                                                                                                                                                                 | `false`  | ${{ github.repository }}              |
-| repositories                   | When using app authentication, the JSON-stringified array of the full names of the repositories the token should have access to. Defaults to all repositories that the installation can access. See https://docs.github.com/en/rest/apps/apps?apiVersion=2022-11-28#create-an-installation-access-token-for-an-app's `repositories`.                                                                   | `false`  |                                       |
-| permissions                    | JSON-stringified permissions granted to the app token. Defaults to all the GitHub app permissions, see: https://docs.github.com/en/rest/apps/apps#create-an-installation-access-token-for-an-app                                                                                                                                                                                                       | `false`  |                                       |
-| github-api-url                 | Configure github API URL. Default `https://api.github.com`                                                                                                                                                                                                                                                                                                                                             | `false`  | ${{ github.api_url }}                 |
-| github-graphql-url             | Configure github GraphQL URL. Default `https://api.github.com/graphql`                                                                                                                                                                                                                                                                                                                                 | `false`  | ${{ github.graphql_url }}             |
-| repository                     | The full name of the repository to operate on in owner/repo format. Defaults to the current repository.                                                                                                                                                                                                                                                                                                | `false`  | ${{ github.repository }}              |
-| target-branch                  | Branch to open pull release PR against. Defaults to the repository's default branch.                                                                                                                                                                                                                                                                                                                   | `false`  |                                       |
-| target-branch-pattern          | Regular expression pattern to determine if current ref name is a target branch or not. When specified, the action will only run if the current ref name matches the pattern, and the current ref name will be used as the target branch. When not specified, the action will always run, and target the specified target-branch, or the repository's default branch if target-branch is not specified. | `false`  |                                       |
-| config-file                    | Path to config file within the project.                                                                                                                                                                                                                                                                                                                                                                | `false`  | .github/release-please-config.json    |
-| manifest-file                  | Path to manifest file within the project.                                                                                                                                                                                                                                                                                                                                                              | `false`  | .github/.release-please-manifest.json |
+| parameter             | description                                                                                                                                                                                                                                                                                                                                                                                            | required | default                               |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------- | ------------------------------------- |
+| token                 | GitHub token used to authenticate.                                                                                                                                                                                                                                                                                                                                                                     | `false`  | ${{ github.token }}                   |
+| app-id                | ID of the GitHub App to use for authentication. If set, takes precedence over token input.                                                                                                                                                                                                                                                                                                             | `false`  |                                       |
+| private-key           | Private key of the GitHub App (can be Base64 encoded). Required when app-id is provided.                                                                                                                                                                                                                                                                                                               | `false`  |                                       |
+| target-branch         | Branch to open pull release PR against. Defaults to the repository's default branch.                                                                                                                                                                                                                                                                                                                   | `false`  |                                       |
+| target-branch-pattern | Regular expression pattern to determine if current ref name is a target branch or not. When specified, the action will only run if the current ref name matches the pattern, and the current ref name will be used as the target branch. When not specified, the action will always run, and target the specified target-branch, or the repository's default branch if target-branch is not specified. | `false`  |                                       |
+| config-file           | Path to config file within the project.                                                                                                                                                                                                                                                                                                                                                                | `false`  | .github/release-please-config.json    |
+| manifest-file         | Path to manifest file within the project.                                                                                                                                                                                                                                                                                                                                                              | `false`  | .github/.release-please-manifest.json |
 
 <!-- action-docs-inputs -->
 
@@ -301,4 +284,4 @@ when cherry picking.
 
 # License
 
-[CC0 1.0 Universal](http://creativecommons.org/publicdomain/zero/1.0/)
+[CC0 1.0 Universal](https://github.com/krystal/release-please-manifest-action/blob/main/LICENSE)

--- a/action.yml
+++ b/action.yml
@@ -16,43 +16,6 @@ inputs:
     description: >-
       Private key of the GitHub App (can be Base64 encoded). Required when
       app-id is provided.
-  installation-retrieval-mode:
-    description: >-
-      When using app authentication, the mode used to retrieve the installation
-      for which the token will be requested. For more information, see:
-      https://github.com/tibdex/github-app-token/blob/v2/action.yml
-    default: repository
-  installation-retrieval-payload:
-    description: >-
-      When using app authentication, the payload used to retrieve the
-      installation. For more information, see:
-      https://github.com/tibdex/github-app-token/blob/v2/action.yml
-    default: ${{ github.repository }}
-  repositories:
-    description: >-
-      When using app authentication, the JSON-stringified array of the full names
-      of the repositories the token should have access to. Defaults to all
-      repositories that the installation can access. See
-      https://docs.github.com/en/rest/apps/apps?apiVersion=2022-11-28#create-an-installation-access-token-for-an-app's
-      `repositories`.
-  permissions:
-    description: >-
-      JSON-stringified permissions granted to the app token. Defaults to all the
-      GitHub app permissions, see:
-      https://docs.github.com/en/rest/apps/apps#create-an-installation-access-token-for-an-app
-  github-api-url:
-    description: >-
-      Configure github API URL. Default `https://api.github.com`
-    default: ${{ github.api_url }}
-  github-graphql-url:
-    description: >-
-      Configure github GraphQL URL. Default `https://api.github.com/graphql`
-    default: ${{ github.graphql_url }}
-  repository:
-    description: >-
-      The full name of the repository to operate on in owner/repo format.
-      Defaults to the current repository.
-    default: ${{ github.repository }}
   target-branch:
     description: >-
       Branch to open pull release PR against. Defaults to the repository's
@@ -142,38 +105,70 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - name: prepare
+    - name: preflight
       shell: bash
-      id: prepare
+      id: preflight
       run: |
+        echo "❯ Determining if action should run..."
         if [[ -n "$TARGET_BRANCH_PATTERN" ]]; then
+          echo "❯ Evaluating target branch pattern:"
+          echo "❯   - pattern:  $TARGET_BRANCH_PATTERN"
+          echo "❯   - ref name: $GITHUB_REF_NAME"
           if [[ "$GITHUB_REF_NAME" =~ $TARGET_BRANCH_PATTERN ]]; then
+            echo "✔ Target branch pattern matches ref name"
             RUN="true"
-            TARGET="$GITHUB_REF_NAME"
+            TARGET_BRANCH="$GITHUB_REF_NAME"
+          else
+            echo "✘ Target branch pattern does not match ref name"
           fi
         else
           RUN="true"
         fi
 
-        echo "target_branch=${TARGET:-$TARGET_BRANCH}" >> "$GITHUB_OUTPUT"
+        if [[ -z "$RUN" ]]; then
+          echo "✘ Not on a target branch, skipping run."
+        fi
+
+        echo "target-branch=${TARGET_BRANCH}" >> "$GITHUB_OUTPUT"
         echo "run=${RUN:-false}" >> "$GITHUB_OUTPUT"
       env:
         TARGET_BRANCH: "${{ inputs.target-branch }}"
         TARGET_BRANCH_PATTERN: "${{ inputs.target-branch-pattern }}"
-    - uses: tibdex/github-app-token@v2
-      if: steps.prepare.outputs.run == 'true' && inputs.app-id != null && inputs.app-id != ''
+    - name: resolve private key
+      if: >-
+        steps.preflight.outputs.run == 'true' &&
+        inputs.app-id != null &&
+        inputs.app-id != ''
+      id: resolve-private-key
+      shell: bash
+      run: |
+        echo "❯ Detecting private key format..."
+        if [[ "$INPUT_PRIVATE_KEY" =~ ^-----BEGIN ]]; then
+          echo "✔ PEM format detected"
+          private_key="$INPUT_PRIVATE_KEY"
+        else
+          echo "✔ Base64 format detected, decoding..."
+          private_key="$(echo "$INPUT_PRIVATE_KEY" | base64 -d)" &> /dev/null
+        fi
+
+        echo "❯ Formatting private key for output..."
+        private_key="$(echo "$private_key" | awk 'BEGIN {ORS="\\n"} {print}' | head -c -2)" &> /dev/null
+        echo "::add-mask::$private_key"
+        echo "private-key=$private_key" >> "$GITHUB_OUTPUT"
+        echo "✔ Private key format detected and securely passed to create-github-app-token action..."
+      env:
+        INPUT_PRIVATE_KEY: "${{ inputs.private-key }}"
+    - uses: actions/create-github-app-token@v2
+      if: >-
+        steps.preflight.outputs.run == 'true' &&
+        inputs.app-id != null &&
+        inputs.app-id != ''
       id: github-app-token
       with:
-        app_id: ${{ inputs.app-id }}
-        github_api_url: ${{ inputs.github-api-url }}
-        installation_retrieval_mode: ${{ inputs.installation-retrieval-mode }}
-        installation_retrieval_payload: ${{ inputs.installation-retrieval-payload }}
-        permissions: ${{ inputs.permissions }}
-        private_key: ${{ inputs.private-key }}
-        repositories: ${{ inputs.repositories }}
-        revoke: true
+        app-id: ${{ inputs.app-id }}
+        private-key: ${{ steps.resolve-private-key.outputs.private-key }}
     - name: resolve token
-      if: steps.prepare.outputs.run == 'true'
+      if: steps.preflight.outputs.run == 'true'
       id: token
       shell: bash
       run: |-
@@ -182,13 +177,10 @@ runs:
         APP_TOKEN: "${{ steps.github-app-token.outputs.token }}"
         INPUT_TOKEN: "${{ inputs.token }}"
     - uses: googleapis/release-please-action@v4
-      if: steps.prepare.outputs.run == 'true'
+      if: steps.preflight.outputs.run == 'true'
       id: release-please
       with:
         token: ${{ steps.token.outputs.token }}
-        target-branch: ${{ steps.prepare.outputs.target_branch }}
+        target-branch: ${{ steps.preflight.outputs.target-branch }}
         config-file: ${{ inputs.config-file }}
         manifest-file: ${{ inputs.manifest-file }}
-        github-api-url: ${{ inputs.github-api-url }}
-        github-graphql-url: ${{ inputs.github-graphql-url }}
-        repo-url: ${{ inputs.repository }}


### PR DESCRIPTION
Replace deprecated `tibdex/github-app-token` action with the new and official `actions/create-github-app-token` action.

This required removing numerous token related inputs for the action, as the new action does not support the same sets of inputs.

BREAKING CHANGE: Removed various app token related inputs not available in new underlying action. Please see updated list of inputs in README.

---

This pulls in upstream [v3.0.0](https://github.com/jimeh/release-please-manifest-action/releases/tag/v3.0.0) changes from [jimeh/release-please-manifest-action](https://github.com/jimeh/release-please-manifest-action).